### PR TITLE
Add NEUTRA-BALANCE demo full-stack app

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,22 @@
-"# CODING" 
+# NEUTRA-BALANCE
+
+This repository contains a small demonstration of a full-stack web application.
+The frontend uses **React** and **Tailwind CSS** loaded from CDNs. The backend is a
+minimal Python HTTP server that returns a mock meal plan.
+
+## Running
+
+1. Start the server:
+   ```bash
+   python3 server/server.py
+   ```
+   This serves the API on `http://localhost:8000/api/mealplan` and also hosts the
+   static frontend.
+
+2. Open your browser at `http://localhost:8000` to use the app.
+
+## Notes
+
+This implementation avoids external dependencies so the API integration is
+limited to mock data. The structure is kept simple to allow swapping the backend
+with a more robust framework or live data source in the future.

--- a/client/app.js
+++ b/client/app.js
@@ -1,0 +1,83 @@
+const { useState } = React;
+
+function MealCard({ meal }) {
+  return (
+    <div className="border p-2 m-2 bg-white shadow">
+      <h3 className="font-bold">{meal.name}</h3>
+      <p>Calories: {meal.calories}</p>
+      <p>Protein: {meal.macros.protein}g | Carbs: {meal.macros.carbs}g | Fat: {meal.macros.fat}g</p>
+      <p>Price: ${meal.price.toFixed(2)}</p>
+    </div>
+  );
+}
+
+function MealPlanDisplay({ plan }) {
+  return (
+    <div className="mt-4">
+      <h2 className="text-xl font-semibold">Meal Plan</h2>
+      <div className="grid grid-cols-1 md:grid-cols-2">
+        {plan.meals.map((m, idx) => <MealCard key={idx} meal={m} />)}
+      </div>
+      <p className="mt-2 font-bold">Total Price: ${plan.total_price.toFixed(2)}</p>
+    </div>
+  );
+}
+
+function App() {
+  const [budget, setBudget] = useState(30);
+  const [mealsPerDay, setMealsPerDay] = useState(3);
+  const [intent, setIntent] = useState('');
+  const [exclusions, setExclusions] = useState({gluten:false, soy:false, dairy:false, shellfish:false, nightshades:false});
+  const [cuisine, setCuisine] = useState('');
+  const [inventory, setInventory] = useState('');
+  const [plan, setPlan] = useState(null);
+
+  const toggleExclusion = (key) => setExclusions({...exclusions, [key]:!exclusions[key]});
+
+  const generatePlan = async () => {
+    const payload = {budget, mealsPerDay, intent, exclusions, cuisine, inventory: inventory.split(',')};
+    const res = await fetch('/api/mealplan', {method:'POST', headers:{'Content-Type':'application/json'}, body: JSON.stringify(payload)});
+    const data = await res.json();
+    setPlan(data);
+  };
+
+  return (
+    <div className="p-4">
+      <h1 className="text-2xl font-bold mb-4">NEUTRA-BALANCE</h1>
+      <div className="grid grid-cols-1 md:grid-cols-2 gap-4">
+        <div>
+          <label className="block">Daily Budget: ${budget}
+            <input type="range" min="10" max="100" value={budget} onChange={e=>setBudget(parseInt(e.target.value))} className="w-full" />
+          </label>
+          <label className="block mt-2">Meals per day
+            <input type="number" value={mealsPerDay} onChange={e=>setMealsPerDay(parseInt(e.target.value))} className="border ml-2 w-16" />
+          </label>
+          <label className="block mt-2">Optimization intent
+            <input type="text" value={intent} onChange={e=>setIntent(e.target.value)} className="border ml-2" />
+          </label>
+          <div className="mt-2">
+            <span className="font-semibold">Exclusions:</span>
+            {Object.keys(exclusions).map(key => (
+              <label key={key} className="ml-2">
+                <input type="checkbox" checked={exclusions[key]} onChange={()=>toggleExclusion(key)} /> {key}
+              </label>
+            ))}
+          </div>
+          <div className="mt-2">
+            <span className="font-semibold">Cuisine bias:</span>
+            {['Asian','Vegan','Mediterranean'].map(c => (
+              <button key={c} onClick={()=>setCuisine(c)} className={`ml-2 px-2 py-1 border ${cuisine===c?'bg-blue-200':''}`}>{c}</button>
+            ))}
+          </div>
+          <label className="block mt-2">Current inventory (comma separated)
+            <input type="text" value={inventory} onChange={e=>setInventory(e.target.value)} className="border ml-2 w-full" />
+          </label>
+          <button onClick={generatePlan} className="mt-4 px-4 py-2 bg-green-500 text-white">Generate Plan</button>
+        </div>
+      </div>
+      {plan && <MealPlanDisplay plan={plan} />}
+    </div>
+  );
+}
+
+ReactDOM.createRoot(document.getElementById('root')).render(<App />);

--- a/client/index.html
+++ b/client/index.html
@@ -1,0 +1,15 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <title>NEUTRA-BALANCE</title>
+  <script src="https://cdn.tailwindcss.com"></script>
+  <script crossorigin src="https://unpkg.com/react@18/umd/react.development.js"></script>
+  <script crossorigin src="https://unpkg.com/react-dom@18/umd/react-dom.development.js"></script>
+  <script src="https://unpkg.com/@babel/standalone/babel.min.js"></script>
+</head>
+<body class="bg-gray-100">
+  <div id="root"></div>
+  <script type="text/babel" src="app.js"></script>
+</body>
+</html>

--- a/server/package.json
+++ b/server/package.json
@@ -1,0 +1,13 @@
+{
+  "name": "server",
+  "version": "1.0.0",
+  "description": "",
+  "main": "index.js",
+  "scripts": {
+    "test": "echo \"Error: no test specified\" && exit 1"
+  },
+  "keywords": [],
+  "author": "",
+  "license": "ISC",
+  "type": "commonjs"
+}

--- a/server/server.py
+++ b/server/server.py
@@ -1,0 +1,73 @@
+import os
+from http.server import SimpleHTTPRequestHandler, HTTPServer
+import json
+
+CLIENT_DIR = os.path.join(os.path.dirname(__file__), '..', 'client')
+
+MOCK_MEALS = [
+    {
+        "name": "Breakfast",
+        "calories": 400,
+        "price": 3.5,
+        "macros": {"protein": 20, "carbs": 50, "fat": 10}
+    },
+    {
+        "name": "Lunch",
+        "calories": 600,
+        "price": 5.0,
+        "macros": {"protein": 25, "carbs": 70, "fat": 15}
+    },
+    {
+        "name": "Dinner",
+        "calories": 700,
+        "price": 6.0,
+        "macros": {"protein": 30, "carbs": 80, "fat": 20}
+    }
+]
+
+class Handler(SimpleHTTPRequestHandler):
+    def __init__(self, *args, **kwargs):
+        super().__init__(*args, directory=CLIENT_DIR, **kwargs)
+
+    def do_OPTIONS(self):
+        self.send_response(200)
+        self.send_header('Access-Control-Allow-Origin', '*')
+        self.send_header('Access-Control-Allow-Methods', 'GET, POST, OPTIONS')
+        self.send_header('Access-Control-Allow-Headers', 'Content-Type')
+        self.end_headers()
+
+    def end_headers(self):
+        self.send_header('Access-Control-Allow-Origin', '*')
+        super().end_headers()
+
+    def do_POST(self):
+        if self.path == '/api/mealplan':
+            length = int(self.headers.get('Content-Length', 0))
+            body = self.rfile.read(length).decode('utf-8')
+            try:
+                params = json.loads(body)
+            except json.JSONDecodeError:
+                params = {}
+            plan = self.generate_plan(params)
+            self.send_response(200)
+            self.send_header('Content-Type', 'application/json')
+            self.end_headers()
+            self.wfile.write(json.dumps(plan).encode('utf-8'))
+        else:
+            self.send_response(404)
+            self.end_headers()
+
+    def generate_plan(self, params):
+        meals = MOCK_MEALS[:params.get('mealsPerDay', 3)]
+        total_price = sum(m['price'] for m in meals)
+        return {"meals": meals, "total_price": total_price}
+
+
+def run(server_class=HTTPServer, handler_class=Handler, port=8000):
+    server_address = ('', port)
+    httpd = server_class(server_address, handler_class)
+    print(f"Serving on port {port}")
+    httpd.serve_forever()
+
+if __name__ == '__main__':
+    run()


### PR DESCRIPTION
## Summary
- add React frontend served via Python server
- build simple backend using Python's http.server that returns a mock meal plan
- document running the demo

## Testing
- `python3 server/server.py` *(server started)*
- `curl -I http://localhost:8000`
- `curl -s -X POST -H "Content-Type: application/json" -d '{"mealsPerDay":2}' http://localhost:8000/api/mealplan`


------
https://chatgpt.com/codex/tasks/task_e_68434e8f517883248149ad41f68ca446